### PR TITLE
fix time.Tick() not to leak

### DIFF
--- a/pkg/battery/battery.go
+++ b/pkg/battery/battery.go
@@ -35,7 +35,10 @@ func New(device string) (battery Battery, err error) {
 }
 
 func (battery *Battery) Update(quit chan struct{}, duration time.Duration, value chan string, err chan error) {
-	for range time.Tick(duration) {
+	ticker := time.NewTicker(duration)
+	defer ticker.Stop()
+
+	for range ticker.C {
 		select {
 		case <-quit:
 			return

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -20,7 +20,10 @@ func New() Host {
 }
 
 func (host *Host) Update(quit chan struct{}, duration time.Duration, value chan string, err chan error) {
-	for range time.Tick(duration) {
+	ticker := time.NewTicker(duration)
+	defer ticker.Stop()
+
+	for range ticker.C {
 		select {
 		case <-quit:
 			return

--- a/pkg/pulseaudio/pulseaudio.go
+++ b/pkg/pulseaudio/pulseaudio.go
@@ -27,8 +27,10 @@ func New() (pa Pulseaudio, err error) {
 }
 
 func (pa *Pulseaudio) Update(quit chan struct{}, duration time.Duration, value chan string, err chan error) {
+	ticker := time.NewTicker(duration)
+	defer ticker.Stop()
 
-	for range time.Tick(time.Millisecond * 250) {
+	for range ticker.C {
 		select {
 		case <-quit:
 			pa.client.Close()

--- a/pkg/temperature/temperature.go
+++ b/pkg/temperature/temperature.go
@@ -38,7 +38,10 @@ func New(device string) (temperature Temperature, err error) {
 }
 
 func (temperature *Temperature) Update(quit chan struct{}, duration time.Duration, value chan string, err chan error) {
-	for range time.Tick(duration) {
+	ticker := time.NewTicker(duration)
+	defer ticker.Stop()
+
+	for range ticker.C {
 		select {
 		case <-quit:
 			return


### PR DESCRIPTION
```console

SA1015: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (staticcheck)

```